### PR TITLE
redis: add capacity to spawn a redis cluster

### DIFF
--- a/terraform/module-ses/outputs.tf
+++ b/terraform/module-ses/outputs.tf
@@ -21,3 +21,7 @@ output "iam_ses_smtp_user_secret" {
 output "aws_sqs_queue_url" {
   value = "${element(concat(aws_sqs_queue.email_delivery_queue.*.id, list("")), 0)}"
 }
+
+output "elasticache_endpoint" {
+  value = "${aws_elasticache_replication_group.redis-cluster.*.configuration_endpoint_address}"
+}

--- a/terraform/module-ses/redis.tf
+++ b/terraform/module-ses/redis.tf
@@ -1,0 +1,49 @@
+resource "aws_security_group" "redis" {
+  count       = "${var.create_elasticache == "true" ? 1 : 0}"
+  name        = "${var.project}-${var.elasticache_name}-${var.env}"
+  description = "${var.elasticache_name} ${var.env} for ${var.project}"
+  vpc_id      = "${var.vpc_id}"
+
+  ingress {
+    from_port = "${var.elasticache_port}"
+    to_port   = "${var.elasticache_port}"
+    protocol  = "tcp"
+
+    security_groups = [ "${var.elasticache_security_groups}" ]
+  }
+
+  tags {
+    Name       = "${var.project}-${var.elasticache_name}-${var.env}"
+    client     = "${var.customer}"
+    env        = "${var.env}"
+    project    = "${var.project}"
+    role       = "${var.elasticache_name}"
+    cycloid.io = "true"
+  }
+}
+
+resource "aws_elasticache_replication_group" "redis-cluster" {
+  count                         = "${var.create_elasticache == "true" ? 1 : 0}"
+  replication_group_id          = "${var.project}-rc-${var.env}"
+  replication_group_description = "Redis cluster for the SES stack"
+  node_type                     = "${var.elasticache_type}"
+  port                          = "${var.elasticache_port}"
+  engine_version                = "${var.elasticache_engine_version}"
+  parameter_group_name          = "${var.elasticache_parameter_group_name}"
+  automatic_failover_enabled    = "${var.elasticache_automatic_failover_enabled}"
+
+  cluster_mode {
+    replicas_per_node_group = "${var.elasticache_replicas_per_node_group}"
+    num_node_groups         = "${var.elasticache_num_node_groups}"
+  }
+
+  tags {
+    Name       = "${var.project}-${var.elasticache_name}-${var.env}"
+    client     = "${var.customer}"
+    env        = "${var.env}"
+    project    = "${var.project}"
+    role       = "${var.elasticache_name}"
+    cycloid.io = "true"
+  }
+}
+

--- a/terraform/module-ses/variables.tf
+++ b/terraform/module-ses/variables.tf
@@ -9,6 +9,12 @@ variable "project" {
   default = "ses"
 }
 
+# A default is provided to avoid forcing to specify it
+variable "vpc_id" {
+  description = "The VPC ID to use when creating Security Groups entities"
+  default     = "unset"
+}
+
 ###
 # ses
 ###
@@ -20,6 +26,58 @@ variable "mail_domain" {}
 # sns
 ###
 variable "create_sqs" {
-  description = "**true** create a sqs generaly used for bounce email"
-  default     = "true"
+  description = "**true** to create an sqs generaly used for bounce email"
+  default     = "false"
+}
+
+###
+# redis
+###
+variable "create_elasticache" {
+  description = "**true** to create an elasticache generaly used for queuing email"
+  default     = "false"
+}
+
+variable "elasticache_type" {
+  default = "cache.t2.micro"
+}
+
+variable "elasticache_name" {
+  description = "Variable used for tagging / naming resources"
+  default = "redis"
+}
+
+variable "elasticache_port" {
+  default = "6379"
+}
+
+variable "elasticache_parameter_group_name" {
+  default = "default.redis5.0.cluster.on"
+}
+
+variable "elasticache_engine_version" {
+  default = "5.0.0"
+}
+
+variable "elasticache_replicas_per_node_group" {
+  description = "Number of read replica, should be between 0 and 5."
+  default = "1"
+}
+
+variable "elasticache_automatic_failover_enabled" {
+  default = true
+}
+
+variable "elasticache_num_node_groups" {
+  default = "2"
+}
+
+variable "elasticache_security_groups" {
+  description = "Those security groups will be granted access to the elasticache cluster."
+  type        = "list"
+  default     = []
+}
+
+variable "elasticache_maintenance_window" {
+  default = "tue:06:00-tue:07:00"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -19,3 +19,8 @@ output "iam_ses_smtp_user_secret" {
 output "aws_sqs_queue_url" {
   value = "${module.ses.aws_sqs_queue_url}"
 }
+
+# elsticache
+output "elasticache_endpoint" {
+  value = "${module.ses.elasticache_endpoint}"
+}

--- a/terraform/ses.tf.sample
+++ b/terraform/ses.tf.sample
@@ -13,4 +13,18 @@ module "ses" {
 
   # If you need to create a sqs (for example used for bounce emails)
   # create_sqs  = "true"
+
+  # If you need to create an elasticache (for example used for sending/queing emails)
+  # create_elasitcache  = "true"
+  # elasticache_security_groups = ["secgroup1", "secgroup2"]
+  # vpc_id = "vpc-id"
 }
+
+# If you desire create a R53 record for the redis
+# resource "aws_route53_record" "redis" {
+#   zone_id = "xxxx"
+#   name    = "xxxx"
+#   type    = "CNAME"
+#   ttl     = "3600"
+#   records = ["${modue.ses.elasticache_endpoint}"]
+# }


### PR DESCRIPTION
When using SES, it can be useful to have an SQS for bounce email, so can
having a redis cluster be useful for storing/queing email to send them.

This is just like SQS optional and not limited to redis, as elasticache
could also create memcache cluster; but it became fairly common to have
redis usage coupled with email to make it more dynamic.