### PR TITLE
redis: update default params and fix subnet/security_group

### DIFF
--- a/terraform/module-ses/redis.tf
+++ b/terraform/module-ses/redis.tf
@@ -31,6 +31,8 @@ resource "aws_elasticache_replication_group" "redis-cluster" {
   engine_version                = "${var.elasticache_engine_version}"
   parameter_group_name          = "${var.elasticache_parameter_group_name}"
   automatic_failover_enabled    = "${var.elasticache_automatic_failover_enabled}"
+  security_group_ids            = ["${aws_security_group.redis.id}"]
+  subnet_group_name             = "${var.elasticache_subnet_group_name}"
 
   cluster_mode {
     replicas_per_node_group = "${var.elasticache_replicas_per_node_group}"

--- a/terraform/module-ses/variables.tf
+++ b/terraform/module-ses/variables.tf
@@ -73,7 +73,7 @@ variable "elasticache_automatic_failover_enabled" {
 }
 
 variable "elasticache_num_node_groups" {
-  default = "2"
+  default = "1"
 }
 
 variable "elasticache_security_groups" {

--- a/terraform/module-ses/variables.tf
+++ b/terraform/module-ses/variables.tf
@@ -55,6 +55,10 @@ variable "elasticache_parameter_group_name" {
   default = "default.redis5.0.cluster.on"
 }
 
+variable "elasticache_subnet_group_name" {
+  default = ""
+}
+
 variable "elasticache_engine_version" {
   default = "5.0.0"
 }

--- a/terraform/ses.tf.sample
+++ b/terraform/ses.tf.sample
@@ -17,6 +17,7 @@ module "ses" {
   # If you need to create an elasticache (for example used for sending/queing emails)
   # create_elasitcache  = "true"
   # elasticache_security_groups = ["secgroup1", "secgroup2"]
+  # elasticache_subnet_group_name = "cache_subnet"
   # vpc_id = "vpc-id"
 }
 


### PR DESCRIPTION
The default parameters (2 shards / 2 nodes) were a bit high so these have been reduced to 1 shards/2 nodes. The parameters for subnet & security_group were also missing which meant that the Redis would always be created in the default VPC & wouldn't allow access from other sources.